### PR TITLE
src/menu_lan.c: Remove unused duplicate lan_player_info definition, fixing the build with gcc >= 10

### DIFF
--- a/src/menu_lan.c
+++ b/src/menu_lan.c
@@ -37,7 +37,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 
 /* lan_player_type now defined in network.h */
-lan_player_type lan_player_info[MAX_CLIENTS];
 
 /* Local function prototypes: ------------------- */
 void draw_player_table(void);


### PR DESCRIPTION
This broke the build with gcc 10:
https://bugs.debian.org/976513