### PR TITLE
Fix blits in titlescreen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES_TUXMATH
   game.c
   menu.c
   menu_lan.c
+  mysetenv.c
   highscore.c
   lessons.c
   mathcards.c

--- a/src/comets.c
+++ b/src/comets.c
@@ -175,6 +175,8 @@ SDL_Rect player_left_pos = {0};
 
 static help_controls_type help_controls;
 
+SDL_Thread *tts_announcer_thread;
+
 /* Local function prototypes: */
 static int  comets_initialize(void);
 static void comets_cleanup(void);
@@ -4152,7 +4154,6 @@ int tts_announcer(void *unused)
 	return 0;
 }
 void start_tts_announcer_thread(){
-	extern SDL_Thread *tts_announcer_thread;
 	tts_announcer_thread = SDL_CreateThread(tts_announcer,NULL);
 }
 
@@ -4160,5 +4161,3 @@ void stop_tts_announcer_thread(){
 	tts_announcer_switch = 0;
 	T4K_Tts_stop();
 }
-
-

--- a/src/globals.h
+++ b/src/globals.h
@@ -186,7 +186,7 @@ extern char **lesson_list_filenames;
 extern int* lesson_list_goldstars;
 extern int num_lessons;
 
-SDL_Thread *tts_announcer_thread;
+extern SDL_Thread *tts_announcer_thread;
 
 #endif
 

--- a/src/menu_lan.c
+++ b/src/menu_lan.c
@@ -36,8 +36,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include "menu_lan.h"
 
 
-/* lan_player_type now defined in network.h */
-lan_player_type lan_player_info[MAX_CLIENTS];
+/* lan_player_type now defined in network.h; added extern for lan_player_info so it's only defined once */
+extern lan_player_type lan_player_info[MAX_CLIENTS];
 
 /* Local function prototypes: ------------------- */
 void draw_player_table(void);

--- a/src/titlescreen.h
+++ b/src/titlescreen.h
@@ -62,7 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MAX_WORD_SIZE                   8
 
 //MAX_UPDATES needed for TransWipe() and friends:
-#define MAX_UPDATES                     180
+#define MAX_UPDATES                     512
 
 #define WAIT_MS                         2500
 #define FRAMES_PER_SEC                  50


### PR DESCRIPTION
The MAX_UPDATES value is used to set the size of blits, and this apparently needs to match between t4kcommon and tuxmath.  T4kcommon has it set to 512.  Making this change prevents a segfault during the titlescreen.  Hat tip to [Bernhard Übelacker for the find