### PR TITLE
Fix segfault.

### DIFF
--- a/src/titlescreen.h
+++ b/src/titlescreen.h
@@ -62,7 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MAX_WORD_SIZE                   8
 
 //MAX_UPDATES needed for TransWipe() and friends:
-#define MAX_UPDATES                     180
+#define MAX_UPDATES                     512
 
 #define WAIT_MS                         2500
 #define FRAMES_PER_SEC                  50


### PR DESCRIPTION
If MAX_UPDATES isn't set to 512 to match the value in t4kcommon, then the blits structs will be the wrong size and the TransWipe will cause a core dump. 

Hat tip to Bernhard Übelacker for finding it.