### PR TITLE
Make tts_announcer_thread a single definition

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include "titlescreen.h"
 
 Mix_Music *music;
+SDL_Thread *tts_announcer_thread;
 
 void playsound(int snd)
 {

--- a/src/globals.h
+++ b/src/globals.h
@@ -186,7 +186,7 @@ extern char **lesson_list_filenames;
 extern int* lesson_list_goldstars;
 extern int num_lessons;
 
-SDL_Thread *tts_announcer_thread;
+extern SDL_Thread *tts_announcer_thread;
 
 #endif
 


### PR DESCRIPTION
globals.h had a tentative definition of tts_announcer_thread, so every .c that includes it ended up with its own copy. Under -fno-common (gcc 10+ default) the link fails with multiple-definition errors:

  ld: highscore.o:globals.h:189: multiple definition of
  'tts_announcer_thread'; tuxmath.o:globals.h:189: first defined here

Extern in the header, single real definition in audio.c next to the existing Mix_Music *music.